### PR TITLE
Applying feeback

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+rm -rf .angular
+npm link sb-shared-lib
+node --max_old_space_size=4096 "./node_modules/@angular/cli/bin/ng" serve --configuration developpement --host=equal.local --disable-host-check

--- a/src/app/_components/buttons/copy-button/copy-button.component.scss
+++ b/src/app/_components/buttons/copy-button/copy-button.component.scss
@@ -7,11 +7,12 @@ button {
     height: 20px;
     width: 20px;
 
-
-
     mat-icon {
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
       color: #00796b;
       font-size: 15px;
-      padding: 0 0 30px;
     }
   }

--- a/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.html
+++ b/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.html
@@ -71,7 +71,8 @@
             <div class="node_display"
                     [class.hover]="node_selected != node"
                     [class.selected]="node_selected === node"
-                    [matTooltip]="getTitle(node)">
+                    [matTooltip]="getTitle(node)"
+                    >
                 <div class="inner" (click)="onclickSelect(node)">
                     <div class="node-text">
                         <label class="node-icon component-icon component-color-{{node.type}}"><mat-icon>{{type_dict[node.type].icon}}</mat-icon></label>

--- a/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.html
+++ b/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.html
@@ -71,7 +71,7 @@
             <div class="node_display"
                     [class.hover]="node_selected != node"
                     [class.selected]="node_selected === node"
-                    [matTooltip]="getTitle(node)"
+                    [title]="getTitle(node)"
                     >
                 <div class="inner" (click)="onclickSelect(node)">
                     <div class="node-text">

--- a/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.scss
+++ b/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.scss
@@ -176,6 +176,16 @@
         max-width: 200px;
         white-space: normal;
         word-wrap: break-word;
+        white-space: normal !important;
+        max-width: none !important;
+        font-size: 14px;
+      }
+
+      mat-tooltip {
+        white-space: normal !important;
+        max-width: none !important;
+        word-break: break-word;
+        font-size: 14px;
       }
 
 }

--- a/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.ts
+++ b/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.ts
@@ -74,7 +74,7 @@ export class SearchMixedListComponent implements OnInit, OnDestroy {
     // value part of the search bar field (parsed in onSearch() method)
     public search_value: string = '';
     // type part of the search bar field (is parsed in onSearch() method)
-    public search_scope: string = "";
+    public search_scope: string = "package";
 
     // used to render info about components present in filteredData (or data)
     public type_dict: { [id: string]: { icon: string, disp: string } } = ItemTypes.typeDict;
@@ -214,7 +214,7 @@ export class SearchMixedListComponent implements OnInit, OnDestroy {
 
         const { filters, terms } = this.extractFiltersAndTerms(tokens);
 
-        this.search_scope = this.node_type ?? 'package';
+        this.search_scope = this.node_type ?? this.search_scope;
         this.filteredData = this.elements.filter((element: EqualComponentDescriptor) => {
             if (!this.matchesFilters(element, element.name, filters, terms)) {
                 return false;

--- a/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.ts
+++ b/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.ts
@@ -116,10 +116,9 @@ export class SearchMixedListComponent implements OnInit, OnDestroy {
     private loadNodesV2() {
 
         if (this.package_name) {
-            // Si package_name est défini, appelez getComponents
             if (this.node_type) {
                 this.provider.getComponents(this.package_name, this.node_type,this.model_name)
-                    .pipe(takeUntil(this.destroy$)) // Ajout de takeUntil
+                    .pipe(takeUntil(this.destroy$))
                     .subscribe(
                         components => this.handleComponents(components),
                         error => this.handleError(error)
@@ -138,9 +137,8 @@ export class SearchMixedListComponent implements OnInit, OnDestroy {
             }
 
             else{
-                // Si package_name n'est pas défini et qu'il n'y a pas de note_type, utilisez equalComponents$
             this.provider.equalComponents$
-                .pipe(takeUntil(this.destroy$)) // Ajout de takeUntil
+                .pipe(takeUntil(this.destroy$))
                 .subscribe(
                     components => this.handleComponents(components),
                     error => this.handleError(error)
@@ -150,10 +148,11 @@ export class SearchMixedListComponent implements OnInit, OnDestroy {
     }
 
     private handleComponents(components: any[]) {
-        this.elements = [...components]; // Copie superficielle du tableau
+        this.elements = [...components];
         this.filteredData = this.elements;
         this.onSearch();
         this.loading = false;
+
     }
 
     private handleError(error: any) {

--- a/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.ts
+++ b/src/app/_components/search-list/search-mixed-list/search-mixed-list.component.ts
@@ -200,12 +200,7 @@ export class SearchMixedListComponent implements OnInit, OnDestroy {
      */
     public selectSearchScope() {
         console.log('selectSearchScope', this.search_scope);
-        if (this.search_scope !== '' && !this.node_type) {
-            this.inputControl.setValue(this.search_scope + ":" + this.search_value);
-        }
-        else {
-            this.inputControl.setValue(this.search_value);
-        }
+        this.inputControl.setValue(this.search_value);
         this.searchScopeChange.emit(this.search_scope);
         this.onSearch();
     }
@@ -224,7 +219,6 @@ export class SearchMixedListComponent implements OnInit, OnDestroy {
             this.search_scope = this.node_type ?? '';
             this.search_value = splitted[0];
         }
-
         const arrow_split = this.search_value.split(">");
         const search_package = arrow_split.length > 1 ? arrow_split[0] : "";
         const search_args = (arrow_split.length > 1 ? arrow_split.slice(1).join("=>") : arrow_split[0]).split(" ");

--- a/src/app/_components/search-list/search-mixed-list/search-mixed-list.facade.ts
+++ b/src/app/_components/search-list/search-mixed-list/search-mixed-list.facade.ts
@@ -63,6 +63,7 @@ this.destroy$.complete();
     this.search_value=search_value;
     this.search_scope=search_scope
   }
+  
   onSearch() {
     const arrowSplit = this.search_value.split(">");
     const searchPackage = arrowSplit.length > 1 ? arrowSplit[0] : "";

--- a/src/app/in/_services/workbench.service.ts
+++ b/src/app/in/_services/workbench.service.ts
@@ -1,7 +1,7 @@
 import { HttpErrorResponse} from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { forkJoin, from, Observable, of, } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { ApiService } from 'sb-shared-lib';
 import { API_ENDPOINTS } from '../_models/api-endpoints';
 import { EqualComponentDescriptor } from '../_models/equal-component-descriptor.class';
@@ -155,6 +155,15 @@ export class WorkbenchService {
         );
     }
 
+    public collect(entity:string, domain:any[], fields:any[], order:string='id', sort:string='asc', start:number=0, limit:number=25, lang: string = ''){
+        return from(this.api.collect(entity,domain,fields,order,sort,start,limit,lang))
+    }
+
+    public collectAllLanguagesCode(){
+        return this.collect('core\\Lang',[],['code']).pipe(
+            map(response => response.map((lang: { code: string }) => lang.code))
+        );
+    }
     public saveActions(package_name:string, class_name:string,payload:any): Observable<any>{
         const url = API_ENDPOINTS.class.actions.save(package_name, class_name);
         return this.callApi(url,'Actions saved', { payload });

--- a/src/app/in/app.component.ts
+++ b/src/app/in/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, ViewEncapsulation} from '@angular/core';
 import { WorkbenchService } from './_services/workbench.service'
 import { EqualComponentDescriptor } from 'src/app/in/_models/equal-component-descriptor.class';
+import {Router } from '@angular/router';
 
 
 @Component({
@@ -28,19 +29,34 @@ export class AppComponent implements OnInit {
 
     constructor(
             private api: WorkbenchService,
+            private router: Router,
+
         ) { }
 
     handleSearchScopeChange(newScope: string): void {
         this.search_scope = newScope;
         console.log('Received new search scope:', this.search_scope);
-        }
+    }
+
     public async ngOnInit() {
-        /*
-        let args = this.router.retrieveArgs();
-        if(args && args['selected']) {
-            this.selectNode(args['selected']);
+        let restored = history.state?.selectedComponent;
+
+        if (!restored) {
+            const fromStorage = sessionStorage.getItem('selectedComponent');
+            if (fromStorage) {
+                try {
+                    restored = JSON.parse(fromStorage);
+                } catch (e) {
+                    console.warn('Impossible to parse from sessionStorage');
+                }
+            }
         }
-        */
+
+        if (restored) {
+            this.selectedComponent = restored;
+            console.log('Component restored :', this.selectedComponent);
+        }
+
         await this.init();
     }
 
@@ -69,8 +85,13 @@ export class AppComponent implements OnInit {
             this.selectedComponent = undefined;
         } else {
             this.selectedComponent = equalComponent;
+            history.replaceState({ ...history.state, selectedComponent: null }, '');
+            sessionStorage.setItem('selectedComponent', JSON.stringify(this.selectedComponent));
         }
     }
+
+
+
     public areNodesEqual(node1: EqualComponentDescriptor | undefined, node2: EqualComponentDescriptor): boolean {
         return node1?.package_name === node2?.package_name &&
                node1?.name === node2?.name &&

--- a/src/app/in/package/model/model-trad-editor/model-trad-editor.component.html
+++ b/src/app/in/package/model/model-trad-editor/model-trad-editor.component.html
@@ -95,37 +95,44 @@
               <!-- Traduction des champs du modèle -->
               <div *ngIf="entitype !== 'menu'" class="model-items">
                 <mat-grid-list cols="16" rowHeight="2em" gutterSize="8px">
-                  <mat-grid-tile>Translation</mat-grid-tile>
-                  <mat-grid-tile colspan="2">Field</mat-grid-tile>
-                  <mat-grid-tile colspan="3">Label</mat-grid-tile>
-                  <mat-grid-tile colspan="5">Description</mat-grid-tile>
-                  <mat-grid-tile colspan="5">Help</mat-grid-tile>
+                  <mat-grid-tile class="header-tile">Translation</mat-grid-tile>
+                  <mat-grid-tile class="header-tile" colspan="2">Field</mat-grid-tile>
+                  <mat-grid-tile class="header-tile" colspan="3">Label</mat-grid-tile>
+                  <mat-grid-tile class="header-tile" colspan="5">Description</mat-grid-tile>
+                  <mat-grid-tile class="header-tile" colspan="5">Help</mat-grid-tile>
                 </mat-grid-list>
+
                 <mat-grid-list *ngFor="let key of obk(data[lang].model)" cols="16" rowHeight="2em" gutterSize="8px">
                   <mat-grid-tile colspan="1">
                     <mat-checkbox [checked]="data[lang].model[key].is_active"
                                   (change)="data[lang].model[key].is_active = $event.checked">
                     </mat-checkbox>
                   </mat-grid-tile>
+
                   <mat-grid-tile colspan="2">
                     <label class="fieldnamelabel">{{ key }}</label>
                   </mat-grid-tile>
+
                   <ng-container *ngIf="data[lang].model[key].is_active">
-                    <mat-grid-tile colspan="3">
+                    <mat-grid-tile colspan="3" class="editable-cell">
                       <input matInput placeholder="Label" [(ngModel)]="data[lang].model[key].label.value" spellcheck="true">
                     </mat-grid-tile>
-                    <mat-grid-tile colspan="5">
+
+                    <mat-grid-tile colspan="5" class="editable-cell">
                       <input matInput placeholder="Description" [(ngModel)]="data[lang].model[key].description.value" spellcheck="true">
                     </mat-grid-tile>
-                    <mat-grid-tile colspan="5">
+
+                    <mat-grid-tile colspan="5" class="editable-cell">
                       <input matInput placeholder="Help" [(ngModel)]="data[lang].model[key].help.value" spellcheck="true">
                     </mat-grid-tile>
                   </ng-container>
+
                   <ng-container *ngIf="!data[lang].model[key].is_active">
                     <mat-grid-tile colspan="13" class="placeholder"></mat-grid-tile>
                   </ng-container>
                 </mat-grid-list>
               </div>
+
             </div>
           </mat-tab>
 

--- a/src/app/in/package/model/model-trad-editor/model-trad-editor.component.html
+++ b/src/app/in/package/model/model-trad-editor/model-trad-editor.component.html
@@ -52,18 +52,24 @@
 
         <div class="lang-selection" *ngIf="addingLanguage || obk(data).length === 0">
             <mat-form-field appearance="outline">
-            <mat-label>Language code</mat-label>
-            <input matInput [formControl]="langName">
+              <mat-label>Language</mat-label>
+              <mat-select [formControl]="langName">
+                <mat-option *ngFor="let lang of availableLanguages" [value]="lang">
+                  {{ lang }}
+                </mat-option>
+              </mat-select>
             </mat-form-field>
+
             <div class="lang-actions">
-            <button mat-button (click)="stopAddingLanguage()">
+              <button mat-button (click)="stopAddingLanguage()">
                 <mat-icon>close</mat-icon> Cancel
-            </button>
-            <button mat-raised-button color="accent" [disabled]="langName.invalid" (click)="createLanguage()">
+              </button>
+              <button mat-raised-button color="accent" [disabled]="langName.invalid" (click)="createLanguage()">
                 <mat-icon>done</mat-icon> Create
-            </button>
+              </button>
             </div>
-        </div>
+          </div>
+
 
 
         <!-- Onglets de traduction -->

--- a/src/app/in/package/model/model-trad-editor/model-trad-editor.component.scss
+++ b/src/app/in/package/model/model-trad-editor/model-trad-editor.component.scss
@@ -1,8 +1,10 @@
 @import "/src/theme.scss";
 
 // Dark grey border color
+// Dark grey border color
 $bordercolor: #666;
-
+$active-bg: #d3f9d8; // Background color when a field is active
+$inactive-bg: #f5f5f5; // Background color when a field is inactive
 :host {
   display: flex;
   flex-direction: column;
@@ -116,7 +118,10 @@ $bordercolor: #666;
   width: 100%;
   max-width: 300px;
 }
-
+.mat-form-field input {
+    width: 100%;
+    box-sizing: border-box;
+  }
 .nameinput {
   width: 100%;
   max-width: 300px;
@@ -125,7 +130,7 @@ $bordercolor: #666;
 
 .descinput {
   width: 100%;
-  max-width: 600px;
+  max-width: none;
   margin-bottom: 1em;
 }
 
@@ -161,30 +166,30 @@ $bordercolor: #666;
 /* ---------- Tab Content ---------- */
 /* Tab content area with overflow handling */
 .tab-content {
-  flex-grow: 1;
-  padding: 1em;
-  max-height: 550px;
+    flex-grow: 1;
+    padding: 1em;
+    max-height: 550px;
+  }
 
-}
 
 /* ---------- Error Section ---------- */
 /* Styling for error message sections */
 .error-section {
-  margin-top: 1em;
-  padding: 0.5em;
-  border: 1px solid $bordercolor;
-  border-radius: 4px;
-  background-color: #fff8e1;
-  overflow-y: auto;
-  max-height: 100%;
-}
+    margin-top: 1em;
+    padding: 0.5em;
+    border: 1px solid $bordercolor;
+    border-radius: 4px;
+    background-color: #fff8e1;
+    overflow-y: auto;
+    max-height: 100%;
+  }
 
-.error-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5em;
-}
+  .error-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5em;
+  }
 
 
 /* ---------- Adaptive Grid Lists ---------- */
@@ -195,3 +200,131 @@ $bordercolor: #666;
   max-width: 100%;
   overflow-y: auto;
 }
+
+
+
+:host {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 1em;
+  box-sizing: border-box;
+  background-color: #f5f5f5;
+}
+
+.placeholder {
+  background-color: #e0e0e0;
+  border: 1px dashed $bordercolor;
+}
+
+.app-holder {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+}
+
+/* Header labels styling */
+.header-labels {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  flex-wrap: wrap;
+}
+
+/* Header grid tile styling */
+.header-tile {
+  font-weight: bold;
+  text-align: center;
+  background-color: #f0f0f0;
+  border-bottom: 2px solid #ddd;
+  padding: 0.5em;
+  box-sizing: border-box;
+}
+
+/* Custom styling for model items container */
+.model-items {
+  flex-grow: 1;
+  margin-top: 1em;
+  padding: 0.5em;
+  border: 1px solid $bordercolor;
+  border-radius: 4px;
+  background-color: #fafafa;
+  max-height: 350px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #ccc #fafafa;
+}
+
+/* Editable cell styling */
+.editable-cell {
+  background-color: $inactive-bg;
+  transition: background-color 0.3s ease;
+
+  input {
+    width: 100%;
+  }
+
+  &:hover {
+    background-color: $active-bg;
+  }
+}
+
+/* Styling for grid tiles */
+.mat-grid-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5em;
+}
+
+.mat-grid-tile input {
+  padding: 0.5em;
+  width: 100%;
+}
+
+/* Adjusting padding for the grid list */
+.mat-grid-list {
+  width: 100%;
+  max-width: 100%;
+  overflow-y: auto;
+  margin-bottom: 1em;
+}
+
+.mat-grid-list .mat-grid-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5em;
+  text-align: center;
+}
+
+/* Placeholder for non-active items */
+.placeholder {
+  background-color: #e0e0e0;
+}
+
+/* Custom scrollbar for Webkit browsers */
+.model-items::-webkit-scrollbar {
+  width: 8px;
+}
+
+.model-items::-webkit-scrollbar-thumb {
+  background-color: #bbb;
+  border-radius: 4px;
+}
+
+.model-items::-webkit-scrollbar-track {
+  background: #fafafa;
+}
+
+
+

--- a/src/app/in/package/model/model-trad-editor/model-trad-editor.module.ts
+++ b/src/app/in/package/model/model-trad-editor/model-trad-editor.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { ModelTradEditorRoutingModule } from './model-trad-editor-routing.module';
-import { ModelTradEditorComponent, ModelTradJsonComponent } from './model-trad-editor.component';
+import { ModelTradEditorComponent} from './model-trad-editor.component';
 
 import { SharedLibModule } from 'sb-shared-lib';
 import { WorkbenchModule } from 'src/app/_modules/workbench.module';
@@ -10,7 +10,6 @@ import { WorkbenchModule } from 'src/app/_modules/workbench.module';
 @NgModule({
   declarations: [
     ModelTradEditorComponent,
-    ModelTradJsonComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/in/package/models/package-models.component.ts
+++ b/src/app/in/package/models/package-models.component.ts
@@ -71,11 +71,10 @@ export class PackageModelsComponent implements OnInit, OnDestroy {
      * @param eq_route the route that the user has selected
      */
     public async onSelectNode(eq_class: EqualComponentDescriptor) {
-        // Si l'élément est déjà sélectionné, le désélectionner
         if (this.selected_class === eq_class) {
-            this.selected_class = undefined; // ou null, selon votre préférence
+            this.selected_class = undefined;
         } else {
-            this.selected_class = eq_class; // Sinon, sélectionnez l'élément
+            this.selected_class = eq_class;
         }
     }
 


### PR DESCRIPTION
Applying following feedback:
Navigation (Back behavior):
- Model list: when the package is the history, it now redirects to the full package list with selected package
- Filter (package:core invoice  [models])

Translation :
- Language codes are now suggested based on the core_lang table (not free text)
- Layout: editing areas have been made more intuitive
- JSON viewer: use the right JSON viewer

Other: 
- Copy/validation icons were realigned
- Replaced ng-attr with the title attribute properly to avoid text truncation